### PR TITLE
Update Googlemap.php

### DIFF
--- a/classes/Googlemap.php
+++ b/classes/Googlemap.php
@@ -202,11 +202,15 @@ class Googlemap extends \Frontend
             $arrElement['iconAnchor'][1] = floor($arrElement['iconSize'][1]/2) + $arrElement['iconAnchor'][1];
         }
 
-        $objFile = \FilesModel::findByPk($arrElement['overlaySRC']);
-        $arrElement['overlaySRC'] = $objFile->path;
+        if(isset($arrElement['overlaySRC']) && !empty($arrElement['overlaySRC'])) {
+            $objFile = \FilesModel::findByPk($arrElement['overlaySRC']);
+            $arrElement['overlaySRC'] = $objFile->path;		
+        }
 
-        $objFile = \FilesModel::findByPk($arrElement['shadowSRC']);
-        $arrElement['shadowSRC'] = $objFile->path;
+        if(isset($arrElement['shadowSRC']) && !empty($arrElement['shadowSRC'])) {
+            $objFile = \FilesModel::findByPk($arrElement['shadowSRC']);
+            $arrElement['shadowSRC'] = $objFile->path;
+        }
 
         $arrElement['shadowSize'] = deserialize($arrElement['shadowSize']);
 


### PR DESCRIPTION
Hi Christian, :) 
seit Contao 3.4.1: wenn kein shadowSRC und overlaySRC ausgewählt war, bekam ich folgenden Fehler:
Fatal error: Allowed memory size of 104857600 bytes exhausted (tried to allocate 65484 bytes) in ...../contao/system/modules/core/library/Contao/Validator.php on line 281
Sobald ich das Kartenelement deaktiviert habe, verschwand der Fehler.
Nach etwas Recherche fand ich raus, dass $arrElement['overlaySRC'] und $arrElement['shadowSRC'] leer an das Fiels-Model übergeben wurden und in diesen Fehler rannten.
Viele Grüße, 
Stefan