### PR TITLE
Update tl_content.php

### DIFF
--- a/dca/tl_content.php
+++ b/dca/tl_content.php
@@ -18,7 +18,7 @@
  */
  
 $GLOBALS['TL_DCA']['tl_content']['palettes']['__selector__'][] = 'dlh_googlemap_static';
-$GLOBALS['TL_DCA']['tl_content']['palettes']['dlh_googlemaps'] = '{title_legend},type,headline;{map_legend},dlh_googlemap,dlh_googlemap_size,dlh_googlemap_zoom,dlh_googlemap_static,dlh_googlemap_nocss,dlh_googlemap_tabs;{template_legend:hide},dlh_googlemap_template;{protected_legend:hide},protected;{expert_legend:hide},guests,cssID,space;{invisible_legend:hide},invisible,start,stop';
+$GLOBALS['TL_DCA']['tl_content']['palettes']['dlh_googlemaps'] = '{type_legend},type,headline;{map_legend},dlh_googlemap,dlh_googlemap_size,dlh_googlemap_zoom,dlh_googlemap_static,dlh_googlemap_nocss,dlh_googlemap_tabs;{template_legend:hide},dlh_googlemap_template;{protected_legend:hide},protected;{expert_legend:hide},guests,cssID,space;{invisible_legend:hide},invisible,start,stop';
 
 
 /**


### PR DESCRIPTION
{type_legend},type,headline;

Hi Christian. 
Könntest du das bitte ändern. Alle Inhaltslemente von Contao beginnen so. Das nutze ich für meine Grid-Erweiterung indem ich den String {type_legend} replace mit der Grid-Palette.