### PR TITLE
Transfer all content values to the template

### DIFF
--- a/elements/ContentMap.php
+++ b/elements/ContentMap.php
@@ -105,6 +105,7 @@ class ContentMap extends \ContentElement
             }
         }
 
+	$this->Template->moduleSettings = $this->arrData;
         $this->Template->map = $arrMap;
         $this->Template->tabs = $this->dlh_googlemap_tabs;
 


### PR DESCRIPTION
In order for your own DCA supplements to be available in the template, it is useful to transfer the complete data set.
Thanks to Toflar for the suggestion.