### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": ">=5.3",
 	    "contao/core-bundle": "^3.5.1 || ~4.2",
-	    "contao-community-alliance/composer-plugin": "3.*",
+	    "contao-community-alliance/composer-plugin": "~2.4 || ~3.0",
 	    "delahaye/dlh_geocode": ">=1.1.1"
     },
     "autoload": {


### PR DESCRIPTION
Abhängigkeit des composer-plugin etwas gelockert, damit die Erweiterung wieder Contao 3.5.* kompatibel ist.