### PR TITLE
Fix license information in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "keywords":["contao", "googlemaps", "geo", "map"],
     "type": "contao-module",
     "homepage":"https://github.com/delahaye/dlh_googlemaps",
-    "license":"LGPL-3.0+",
+    "license":"LGPL-3.0-or-later",
     "authors":[
         {
             "name":"Christian de la Haye",


### PR DESCRIPTION
Ohne diese Änderung wird Packagist nicht updaten.

// wobei Packagist das nun doch durchgehen lässt, wie es scheint: https://packagist.org/packages/delahaye/dlh_googlemaps

Vor einiger Zeit gab es bei Packagist eine Änderung, sodass die license Angabe [SPDX](https://spdx.org/licenses/) kompatibel sein musste. Alles was nicht exakt dem Standard entsprach, wurde nicht aufgenommen. Vielleicht hat Packagist das wieder geändert. Trotzdem sollte man dem SPDX Standard folgen.