### PR TITLE
Fix UpgradeHandler for Contao 4.9+

### DIFF
--- a/classes/UpgradeHandler.php
+++ b/classes/UpgradeHandler.php
@@ -19,6 +19,8 @@
  */
 namespace delahaye\googlemaps;
 
+use Contao\Database\Result;
+
 
 /**
  * Class UpgradeHandler
@@ -79,9 +81,14 @@ class UpgradeHandler
     }
 
 
+    /**
+     * @param Result $objList
+     */
     private static function upGradeMapSize($objDatabase, $objList, $strTable, $strField){
-        while($objList->next()){
-            $tmpOld = deserialize($objList->$strField);
+        $records = $objList->fetchAllAssoc();
+
+        foreach ($records as $record) {
+            $tmpOld = deserialize($record[$strField]);
             $tmpNew = array();
             if($tmpOld[2] != 'box' && $tmpOld[2] != 'proportional'){
                 $tmpOld[2] = str_replace('pcnt','%',$tmpOld[2]);
@@ -89,7 +96,7 @@ class UpgradeHandler
                 $tmpNew[1] = $tmpOld[1] > 0 ? $tmpOld[1].$tmpOld[2] : '';
                 $tmpNew[2] = 'box';
 
-                $objDatabase->prepare("update ".$strTable." set ".$strField."=? where id=?")->execute(serialize($tmpNew), $objList->id);
+                $objDatabase->prepare("update ".$strTable." set ".$strField."=? where id=?")->execute(serialize($tmpNew), $record['id']);
             }
         }
 


### PR DESCRIPTION
Since Contao 4.9.0 the result within `\Contao\Database\Result` is buffered. This leads to the following error when updating from an older version of the extension to a newer one:

> Cannot execute queries while other unbuffered queries are active.

This is because MySQL does not allow you to execute an `UPDATE` or `INSERT` on the same table where a result from a `SELECT` is still buffered. To fix this we first need to fetch all the records of the previous `SELECT` and then traverse these fetched records instead.